### PR TITLE
Add placeholder for manual deployment

### DIFF
--- a/.github/workflows/manual-deployment.yml
+++ b/.github/workflows/manual-deployment.yml
@@ -1,0 +1,18 @@
+# This workflow manually deploys SauNah frontend from the tag given
+# to either staging or production
+# This implementation is a placeholder on the main branch
+# to allow developing and testing on another branch.
+
+name: Manual Deployment (placeholder)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  placeholder:
+    name: Placeholder Job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: |
+          echo "Placeholder"


### PR DESCRIPTION
## Summary

- This adds a placeholder pipeline. This is necessary as pipelines can only be triggered manually when the action exists on the main branch. As soon as it exists, it can also be run from another branch. Thus, this is a placeholder which can be merged to main, which then allows to implement the real feature in #30 and test it properly before merging to main.

## Related Issues

## Definition of Done

- User story
  - [x] All stated conditions fulfilled
- Code
  - [ ] No more code needed
  - [ ] No known bugs
- Clean Code
  - [ ] Documentation for functions containing logic and components has been added
- Testing
  - [ ] All existing tests pass
  - [ ] New unit tests created according to [CONTRIBUTING.md](./CONTRIBUTING.md#-testing-strategy)
  - [ ] New unit tests pass
- SonarCloud
  - [ ] Quality gate passed
- Compatibility to backend
  - [ ] Compatibility to staging-backend ([https://saunah-backend-staging.k8s.init-lab.ch](https://saunah-backend-staging.k8s.init-lab.ch)) verified
- Not behind `main`
  - [ ] This branch is not behind `main` branch, (current `main` is merged into this branch)
