### PR TITLE
Adapt for api change to include image url instead of file name

### DIFF
--- a/src/components/saunas/SaunaCard.tsx
+++ b/src/components/saunas/SaunaCard.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Sauna } from '../../entities/Sauna'
 import { SaunaImage } from '../../entities/SaunaImage'
 import api from '../../networking/api'
-import apiRoutes, { getAbsoluteUrl } from '../../networking/apiRoutes'
 import ButtonLink from '../base/ButtonLink'
 
 export type SaunaCardProps = {
@@ -12,7 +11,7 @@ export type SaunaCardProps = {
 
 const SaunaCard = (props: SaunaCardProps) => {
     const [images, setImages] = useState<SaunaImage.Response[]>([])
-    const imgLink = images[0] ? getAbsoluteUrl(apiRoutes.saunaImages.get(images[0].fileName)) : ''
+    const imgLink = images[0] ? images[0].url : ''
     const navLink = `/saunas/${props.sauna.id}`
 
     useEffect(() => {

--- a/src/components/saunas/SaunaImageCarousel.test.tsx
+++ b/src/components/saunas/SaunaImageCarousel.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { SaunaImage } from '../../entities/SaunaImage'
-import apiRoutes, { getAbsoluteUrl } from '../../networking/apiRoutes'
+import { SaunaImagesMock } from '../../networking/api/saunaImages.mock'
 import SaunaImageCarousel from './SaunaImageCarousel'
 
 describe('<SaunaImageCarousel>', () => {
@@ -9,29 +8,11 @@ describe('<SaunaImageCarousel>', () => {
         images.forEach(image => {
             screen.getAllByTestId(`image-${image.id}`).forEach(element => {
                 expect(element).toHaveStyle({
-                    backgroundImage: `url(${getAbsoluteUrl(apiRoutes.saunaImages.get(image.fileName))})`,
+                    backgroundImage: `url(${image.url})`,
                 })
             })
         })
     })
 })
 
-const image1: SaunaImage.Response = {
-    id: 1,
-    saunaId: 1,
-    fileName: 'file-1',
-}
-
-const image2: SaunaImage.Response = {
-    id: 2,
-    saunaId: 2,
-    fileName: 'file-2',
-}
-
-const image3: SaunaImage.Response = {
-    id: 3,
-    saunaId: 3,
-    fileName: 'file-3',
-}
-
-const images = [image1, image2, image3]
+const images = [SaunaImagesMock.sampleResponse1, SaunaImagesMock.sampleResponse2, SaunaImagesMock.sampleResponse3]

--- a/src/components/saunas/SaunaImageCarousel.tsx
+++ b/src/components/saunas/SaunaImageCarousel.tsx
@@ -2,7 +2,7 @@ import Slider, { Settings } from 'react-slick'
 import 'slick-carousel/slick/slick.css'
 import 'slick-carousel/slick/slick-theme.css'
 import { SaunaImage } from '../../entities/SaunaImage'
-import apiRoutes, { getAbsoluteUrl } from '../../networking/apiRoutes'
+import { getAbsoluteUrl } from '../../networking/apiRoutes'
 import { useRef } from 'react'
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/solid'
 import './SaunaImageCarousel.css'
@@ -30,14 +30,12 @@ const SaunaImageCarousel = (props: SaunaImageCarouselProps) => {
             <div className="px-8 bg-primary-100">
                 <Slider {...settings} ref={ref}>
                     {props.images.map(image => (
-                        <div key={image.fileName}>
+                        <div key={image.url}>
                             <div
                                 data-testid={`image-${image.id}`}
                                 className="h-60 md:h-80 lg:h-96 bg-contain bg-no-repeat bg-center"
                                 style={{
-                                    backgroundImage: `url(${getAbsoluteUrl(
-                                        apiRoutes.saunaImages.get(image.fileName)
-                                    )})`,
+                                    backgroundImage: `url(${getAbsoluteUrl(image.url)})`,
                                 }}
                             />
                         </div>

--- a/src/components/saunas/SaunaImageEditor.test.tsx
+++ b/src/components/saunas/SaunaImageEditor.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
-import { SaunaImage } from '../../entities/SaunaImage'
+import { SaunaImagesMock } from '../../networking/api/saunaImages.mock'
 import SaunaImageEditor from './SaunaImageEditor'
 
 describe('<SaunaImageEditor>', () => {
@@ -18,7 +18,7 @@ describe('<SaunaImageEditor>', () => {
         for (let i = 1; i <= 3; i++) {
             fireEvent.click(getRemoveButton(i))
             expect(remove).toBeCalledTimes(i)
-            expect(remove).toBeCalledWith({ id: i, saunaId: i, fileName: `file-${i}` })
+            expect(remove).toBeCalledWith({ id: i, saunaId: i, url: `http://localhost/test-sauna-${i}.jpg` })
         }
     })
 })
@@ -27,22 +27,4 @@ const getEditor = () => screen.getByTestId('sauna-image-editor')
 const getImage = (id: number) => within(getEditor()).getByTestId('image-' + id)
 const getRemoveButton = (id: number) => within(getEditor()).getByTestId('remove-button-' + id)
 
-const image1: SaunaImage.Response = {
-    id: 1,
-    saunaId: 1,
-    fileName: 'file-1',
-}
-
-const image2: SaunaImage.Response = {
-    id: 2,
-    saunaId: 2,
-    fileName: 'file-2',
-}
-
-const image3: SaunaImage.Response = {
-    id: 3,
-    saunaId: 3,
-    fileName: 'file-3',
-}
-
-const images = [image1, image2, image3]
+const images = [SaunaImagesMock.sampleResponse1, SaunaImagesMock.sampleResponse2, SaunaImagesMock.sampleResponse3]

--- a/src/components/saunas/SaunaImageEditor.tsx
+++ b/src/components/saunas/SaunaImageEditor.tsx
@@ -1,5 +1,4 @@
 import { SaunaImage } from '../../entities/SaunaImage'
-import apiRoutes, { getAbsoluteUrl } from '../../networking/apiRoutes'
 import IconButton from '../base/IconButton'
 import { TrashIcon } from '@heroicons/react/solid'
 
@@ -13,7 +12,7 @@ const SaunaImageEditor = (props: SaunaImageEditorProps) => {
     return (
         <div className={props.className + ' flex flex-wrap gap-4'} data-testid="sauna-image-editor">
             {props.images.map(image => (
-                <div key={image.fileName} className="relative h-40">
+                <div key={image.url} className="relative h-40">
                     <IconButton
                         data-testid={'remove-button-' + image.id}
                         icon={TrashIcon}
@@ -23,12 +22,7 @@ const SaunaImageEditor = (props: SaunaImageEditorProps) => {
                         onClick={() => props.onRemove?.(image)}
                     />
 
-                    <img
-                        data-testid={'image-' + image.id}
-                        className="h-full"
-                        src={getAbsoluteUrl(apiRoutes.saunaImages.get(image.fileName))}
-                        alt={image.fileName}
-                    />
+                    <img data-testid={'image-' + image.id} className="h-full" src={image.url} alt="" />
                 </div>
             ))}
         </div>

--- a/src/entities/SaunaImage.test.ts
+++ b/src/entities/SaunaImage.test.ts
@@ -1,23 +1,20 @@
+import { SaunaImagesMock } from '../networking/api/saunaImages.mock'
 import { SaunaImage } from './SaunaImage'
-
-const testRemoteResponse: SaunaImage.RemoteResponse = {
-    id: 1,
-    saunaId: 2,
-    fileName: 'file-3',
-}
 
 describe('SaunaImage', () => {
     test('isRemoveResponse() works correctly', () => {
-        expect(SaunaImage.isRemoteResponse(testRemoteResponse)).toBe(true)
+        expect(SaunaImage.isRemoteResponse(SaunaImagesMock.sampleRemoteResponse1)).toBe(true)
         expect(SaunaImage.isRemoteResponse(null)).toBe(false)
         expect(SaunaImage.isRemoteResponse({})).toBe(false)
-        Object.keys(testRemoteResponse).forEach(key => {
-            expect(SaunaImage.isRemoteResponse({ ...testRemoteResponse, [key]: undefined })).toBe(false)
+        Object.keys(SaunaImagesMock.sampleRemoteResponse1).forEach(key => {
+            expect(SaunaImage.isRemoteResponse({ ...SaunaImagesMock.sampleRemoteResponse1, [key]: undefined })).toBe(
+                false
+            )
         })
     })
 
     test('mapIn() only works with correct input entity', () => {
-        expect(SaunaImage.mapIn(testRemoteResponse)).toBeTruthy()
+        expect(SaunaImage.mapIn(SaunaImagesMock.sampleRemoteResponse1)).toBeTruthy()
         expect(() => SaunaImage.mapIn({})).toThrow()
     })
 })

--- a/src/entities/SaunaImage.ts
+++ b/src/entities/SaunaImage.ts
@@ -2,7 +2,7 @@ export namespace SaunaImage {
     export type Response = {
         id: number
         saunaId: number
-        fileName: string
+        url: string
     }
 
     export type RemoteResponse = Response
@@ -13,7 +13,7 @@ export namespace SaunaImage {
             image != null &&
             typeof image.id === 'number' &&
             typeof image.saunaId === 'number' &&
-            typeof image.fileName === 'string'
+            typeof image.url === 'string'
         )
     }
 

--- a/src/networking/api/saunaImages.mock.ts
+++ b/src/networking/api/saunaImages.mock.ts
@@ -9,9 +9,27 @@ export namespace SaunaImagesMock {
         }
     }
 
-    const sampleResponse1: SaunaImage.Response = {
+    export const sampleResponse1: SaunaImage.Response = {
         id: 1,
         saunaId: 1,
-        fileName: 'test-sauna-1',
+        url: 'http://localhost/test-sauna-1.jpg',
+    }
+
+    export const sampleResponse2: SaunaImage.Response = {
+        id: 2,
+        saunaId: 2,
+        url: 'http://localhost/test-sauna-2.jpg',
+    }
+
+    export const sampleResponse3: SaunaImage.Response = {
+        id: 3,
+        saunaId: 3,
+        url: 'http://localhost/test-sauna-3.jpg',
+    }
+
+    export const sampleRemoteResponse1: SaunaImage.RemoteResponse = {
+        id: 1,
+        saunaId: 2,
+        url: 'http://localhost/test-sauna-2.jpg',
     }
 }


### PR DESCRIPTION
## Summary

- This changes the `SaunaImage` type in order for it to work with the changed API that will send urls to the image instead of the filename. Should be merged right after https://github.com/saunah/saunah-backend/pull/83

## Related Issues

## Definition of Done

- User story
  - [x] All stated conditions fulfilled
- Code
  - [x] No more code needed
  - [x] No known bugs
- Clean Code
  - [x] Documentation for functions containing logic and components has been added
- Testing
  - [x] All existing tests pass
  - [x] New unit tests created according to [CONTRIBUTING.md](./CONTRIBUTING.md#-testing-strategy)
  - [x] New unit tests pass
- SonarCloud
  - [x] Quality gate passed
- Compatibility to backend
  - ~Compatibility to staging-backend ([https://saunah-backend-staging.k8s.init-lab.ch](https://saunah-backend-staging.k8s.init-lab.ch)) verified~ **Breaking Change**, not that serious, however, as images didn't work before anyway.
- Not behind `main`
  - [x] This branch is not behind `main` branch, (current `main` is merged into this branch)
