### PR TITLE
Simplify footer to only include copyright

### DIFF
--- a/src/components/structural/AppFooter.tsx
+++ b/src/components/structural/AppFooter.tsx
@@ -7,15 +7,8 @@ import { ReactNode } from 'react'
 const AppFooter = (props: AppFooterProps) => {
     return (
         <footer className="p-4 w-full bg-primary-100 rounded-3xl" data-testid="app-footer">
-            <div className="container w-full mx-auto max-w-screen-xl py-8 flex flex-row flex-1 items-center justify-center">
-                <div className="basis-0 grow">
-                    {/* Left column content */}
-                    {props.children}
-                </div>
-                <div className="basis-0 grow">
-                    {/* Right column content */}
-                    <span>Right Column</span>
-                </div>
+            <div className="container w-full mx-auto max-w-screen-xl p-2 flex flex-row flex-1 items-center justify-center">
+                <div className="basis-0 grow text-center">{props.children}</div>
             </div>
         </footer>
     )

--- a/src/views/shared/Footer.tsx
+++ b/src/views/shared/Footer.tsx
@@ -7,7 +7,7 @@ import AppFooter from '../../components/structural/AppFooter'
 const Footer = () => {
     return (
         <AppFooter>
-            <span> REACT_APP_API_BASE_URL: {process.env.REACT_APP_API_BASE_URL || '-'} </span>
+            <span>&copy; {`${new Date().getFullYear()} SauNah`}</span>
         </AppFooter>
     )
 }


### PR DESCRIPTION
## Summary

- Removes demo content from the footer and replaces it with a simple `© 2022 SauNah`, where the year is dynamic, of course ;)

## Related Issues

## Definition of Done

- User story
  - [x] All stated conditions fulfilled
- Code
  - [x] No more code needed
  - [x] No known bugs
- Clean Code
  - [x] Documentation for functions containing logic and components has been added
- Testing
  - [x] All existing tests pass
  - [x] New unit tests created according to [CONTRIBUTING.md](./CONTRIBUTING.md#-testing-strategy)
  - [x] New unit tests pass
- SonarCloud
  - [x] Quality gate passed
- Compatibility to backend
  - [x] Compatibility to staging-backend ([https://saunah-backend-staging.k8s.init-lab.ch](https://saunah-backend-staging.k8s.init-lab.ch)) verified
- Not behind `main`
  - [x] This branch is not behind `main` branch, (current `main` is merged into this branch)
