### PR TITLE
Update deployment properties

### DIFF
--- a/helm/saunah-frontend/templates/deployment.yaml
+++ b/helm/saunah-frontend/templates/deployment.yaml
@@ -10,6 +10,9 @@ spec:
   selector:
     matchLabels:
       {{- include "saunah-frontend.selectorLabels" . | nindent 6 }}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
this prevents issues with resource shortage

## Summary

- Allows 1 pod to be down when new version is deployed, which prevents errors if there are not enough resources to deploy a new version while keeping an old one running before the new is ready
